### PR TITLE
Added localStorage support for caching fetch result

### DIFF
--- a/src/react-app/src/App.tsx
+++ b/src/react-app/src/App.tsx
@@ -6,6 +6,7 @@ import ClassroomList from "./components/ui/ClassroomList";
 import type { ISchedule } from "@/types";
 import extractSheetId from "./lib/extractSheetId";
 import getDayIndex from "./lib/getDayIndex";
+import { saveToStorage, getFromStorage } from "./lib/utils";
 
 let static_section: string;
 
@@ -20,12 +21,15 @@ function App() {
   useEffect(() => {
     (async () => {
       try {
-        const response = await fetch("/timetable");
-        if (!response.ok) {
-          const errorData = await response.json();
-          return setErrorMessage(errorData.detail);
+        if (!getFromStorage()) {
+          const response = await fetch("/timetable");
+          if (!response.ok) {
+            const errorData = await response.json();
+            return setErrorMessage(errorData.detail);
+          }
+          saveToStorage(await response.json());
         }
-        const result = await response.json();
+        const result = getFromStorage();
 
         setTimeTable(result.time_table);
         setSheetLink(result.url);
@@ -73,6 +77,7 @@ function App() {
                 return;
               }
               const result = await response.json();
+              saveToStorage(result);
 
               setTimeTable(result.time_table);
               setFreeClasses(result.free_classes);

--- a/src/react-app/src/lib/utils.ts
+++ b/src/react-app/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+const saveToStorage = (value: object) => {
+  localStorage.setItem("data", JSON.stringify(value));
+}
+
+const getFromStorage = () => {
+  const storedData = localStorage.getItem("data");
+  return storedData ? JSON.parse(storedData) : null;
+};
+
+export { saveToStorage, getFromStorage };


### PR DESCRIPTION
## Small changes to add caching!

This update implements localStorage to store the timetable after fetching. On subsequent fetches, the application checks for cached data and uses it if available, improving performance and reducing unnecessary API calls.

Tested this with default `BCS-5G` timetable, it appears to be working fine.